### PR TITLE
docs: add 'editable: true' to example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ import {
 } from 'lexical-vue'
 
 const config = {
+  editable: true,
   theme: {
     // Theme styling goes here
   },


### PR DESCRIPTION
It is confusing that the example doesn't work out of the box. It took me a while to figure out that I had to set `editable: true` in the config to be able to edit the content.