### PR TITLE
Remove extra function wrapper that was breaking DecoratorNode

### DIFF
--- a/src/composables/useDecorators.ts
+++ b/src/composables/useDecorators.ts
@@ -24,7 +24,7 @@ export function useDecorators(editor: LexicalEditor) {
         decoratedTeleports.push(
           h(Teleport, {
             to: element,
-          }, () => [vueDecorator]),
+          }, vueDecorator),
         )
       }
     }


### PR DESCRIPTION
Per [this message in discord](https://discord.com/channels/953974421008293909/956476669600862218/1084999763532988466) and [this Loom video](https://www.loom.com/share/b54fd5f16978420baf2cda678d7e2b34) I can't get `DecoratorNode`s to work.

Making the change in this PR seems to fix the issue for me. `DecoratorNode`s seem to function as intended after the fix with no other obvious breakages.

Please let me know what else I can do.