### PR TITLE
Move placeholder behind caret

### DIFF
--- a/src/components/LexicalPlainTextPlugin.vue
+++ b/src/components/LexicalPlainTextPlugin.vue
@@ -8,7 +8,7 @@ usePlainTextSetup(editor)
 </script>
 
 <template>
-  <slot name="contentEditable" />
   <slot v-if="showPlaceholder" name="placeholder" />
+  <slot name="contentEditable" />
   <Decorators />
 </template>

--- a/src/components/LexicalRichTextPlugin.vue
+++ b/src/components/LexicalRichTextPlugin.vue
@@ -8,7 +8,7 @@ useRichTextSetup(editor)
 </script>
 
 <template>
-  <slot name="contentEditable" />
   <slot v-if="showPlaceholder" name="placeholder" />
+  <slot name="contentEditable" />
   <Decorators />
 </template>


### PR DESCRIPTION
Hey again @wobsoriano, hope you're doing well.

I found that the placeholder appears on top of the caret. By swapping the order of these slots the placeholder appears behind the caret.

| Before | After |
|--------|--------|
| ![Screenshot 2023-03-29 at 10 35 19 PM](https://user-images.githubusercontent.com/7647688/228739736-2fa0c03f-39d7-44d2-80c5-ba9bb5d1502e.png) | ![Screenshot 2023-03-29 at 10 37 07 PM](https://user-images.githubusercontent.com/7647688/228739744-1b80b083-f1de-429a-a30f-921d5d31dfc0.png) |

Let me know if I can improve or if you'd like these PRs in a different format. I expect there may be more like this if that's cool with you.