### PR TITLE
Move checklist listener management to helper to prevent duplicate events

### DIFF
--- a/src/components/LexicalCheckListPlugin.vue
+++ b/src/components/LexicalCheckListPlugin.vue
@@ -32,6 +32,7 @@ import {
 import { $findMatchingParent, mergeRegister } from '@lexical/utils'
 import { useEditor } from '../composables'
 import { useMounted } from '../composables/useMounted'
+import { incrementClickAndPointerDownListenersCount, decrementClickAndPointerDownListenersCount } from '../composoables/listenerManager'
 
 const editor = useEditor()
 
@@ -136,16 +137,15 @@ useMounted(() => {
   )
 })
 
-let listenersCount = 0
 function listenPointerDown() {
-  if (listenersCount++ === 0) {
+  if (incrementClickAndPointerDownListenersCount()) {
     // @ts-expect-error: speculation ambiguous
     document.addEventListener('click', handleClick)
     document.addEventListener('pointerdown', handlePointerDown)
   }
 
   return () => {
-    if (--listenersCount === 0) {
+    if (decrementClickAndPointerDownListenersCount()) {
       // @ts-expect-error: speculation ambiguous
       document.removeEventListener('click', handleClick)
       document.removeEventListener('pointerdown', handlePointerDown)

--- a/src/components/LexicalCheckListPlugin.vue
+++ b/src/components/LexicalCheckListPlugin.vue
@@ -32,7 +32,7 @@ import {
 import { $findMatchingParent, mergeRegister } from '@lexical/utils'
 import { useEditor } from '../composables'
 import { useMounted } from '../composables/useMounted'
-import { incrementClickAndPointerDownListenersCount, decrementClickAndPointerDownListenersCount } from '../composoables/listenerManager'
+import { incrementCheckListListenersCount, decrementCheckListListenersCount } from '../composables/listenerManager'
 
 const editor = useEditor()
 
@@ -138,14 +138,14 @@ useMounted(() => {
 })
 
 function listenPointerDown() {
-  if (incrementClickAndPointerDownListenersCount()) {
+  if (incrementCheckListListenersCount()) {
     // @ts-expect-error: speculation ambiguous
     document.addEventListener('click', handleClick)
     document.addEventListener('pointerdown', handlePointerDown)
   }
 
   return () => {
-    if (decrementClickAndPointerDownListenersCount()) {
+    if (decrementCheckListListenersCount()) {
       // @ts-expect-error: speculation ambiguous
       document.removeEventListener('click', handleClick)
       document.removeEventListener('pointerdown', handlePointerDown)

--- a/src/composables/listenerManager.ts
+++ b/src/composables/listenerManager.ts
@@ -1,9 +1,9 @@
 let handleClickAndPointerDownListenersCount = 0
 
-function incrementClickAndPointerDownListenersCount() {
-  return handleClickAndPointerDownListenersCount ++ === 0
+export function incrementCheckListListenersCount() {
+  return handleClickAndPointerDownListenersCount++ === 0
 }
 
-function decrementClickAndPointerDownListenersCount() {
+export function decrementCheckListListenersCount() {
   return --handleClickAndPointerDownListenersCount === 0
 }

--- a/src/composables/listenerManager.ts
+++ b/src/composables/listenerManager.ts
@@ -1,0 +1,9 @@
+let handleClickAndPointerDownListenersCount = 0
+
+function incrementClickAndPointerDownListenersCount() {
+  return handleClickAndPointerDownListenersCount ++ === 0
+}
+
+function decrementClickAndPointerDownListenersCount() {
+  return --handleClickAndPointerDownListenersCount === 0
+}


### PR DESCRIPTION
# Background

As it stands now, making multiple instances of `<LexicalCheckListPlugin>` (e.g. with two editors on one page) will instantiate separate instances of `let listenersCount = 0` and therefore both (or all) of the editors will separately register document-level event listeners for `click` and `pointerDown`.

# Repro

Make an even number of editors in one page, each with the checklist plugin. An even number of listeners are registered on the document. When a checkbox is clicked an even number of `handeClick`s are fired and the checkbox is toggled an even number of times. From a user's perspective the box does not change on click.

# Notes

Does the fix make sense and work? This was the best fix I found but happy to implement a different way if preferable.
