### PR TITLE
Use CreateEditorArgs from lexical as config prop

### DIFF
--- a/src/components/LexicalComposer.vue
+++ b/src/components/LexicalComposer.vue
@@ -1,23 +1,12 @@
 <script setup lang="ts">
 import { onMounted, provide } from 'vue'
-import type { EditorThemeClasses, Klass, LexicalEditor, LexicalNode } from 'lexical'
+import type { CreateEditorArgs, LexicalEditor } from 'lexical'
 import { $createParagraphNode, $getRoot, $getSelection, createEditor } from 'lexical'
 import { editorKey } from '../composables/inject'
 import type { InitialEditorStateType } from '../types'
 
 const props = defineProps<{
-  initialConfig: {
-    namespace?: string
-    nodes?: (Klass<LexicalNode> | {
-      replace: Klass<LexicalNode>
-      with: <T extends { new (...args: any): any }>(
-        node: InstanceType<T>,
-      ) => LexicalNode
-    })[]
-    editable?: boolean
-    theme?: EditorThemeClasses
-    editorState?: InitialEditorStateType
-  }
+  initialConfig: CreateEditorArgs
 }>()
 
 const emit = defineEmits<{


### PR DESCRIPTION
This PR removes the hardcoded type for `initialConfig`

Perhaps a bump in lexical should be done too?

Another change that needs to happen is the playground `Editor.vue` config needs to be updated to properly initialize the `editorState`. I'm not familiar enough with the `lexical` api to figure that part out.