### PR TITLE
Fix checkbox click listeners again

### DIFF
--- a/src/components/LexicalCheckListPlugin.vue
+++ b/src/components/LexicalCheckListPlugin.vue
@@ -32,7 +32,7 @@ import {
 import { $findMatchingParent, mergeRegister } from '@lexical/utils'
 import { useEditor } from '../composables'
 import { useMounted } from '../composables/useMounted'
-import { decrementCheckListListenersCount, incrementCheckListListenersCount } from '../composables/listenerManager'
+import { registerClickAndPointerListenersIfUnregistered } from '../composables/listenerManager'
 
 const editor = useEditor()
 
@@ -138,19 +138,15 @@ useMounted(() => {
 })
 
 function listenPointerDown() {
-  if (incrementCheckListListenersCount()) {
+  return registerClickAndPointerListenersIfUnregistered(() => {
     // @ts-expect-error: speculation ambiguous
     document.addEventListener('click', handleClick)
     document.addEventListener('pointerdown', handlePointerDown)
-  }
-
-  return () => {
-    if (decrementCheckListListenersCount()) {
-      // @ts-expect-error: speculation ambiguous
-      document.removeEventListener('click', handleClick)
-      document.removeEventListener('pointerdown', handlePointerDown)
-    }
-  }
+  }, () => {
+    // @ts-expect-error: speculation ambiguous
+    document.removeEventListener('click', handleClick)
+    document.removeEventListener('pointerdown', handlePointerDown)
+  })
 }
 
 function handleCheckItemEvent(event: PointerEvent, callback: () => void) {

--- a/src/components/LexicalCheckListPlugin.vue
+++ b/src/components/LexicalCheckListPlugin.vue
@@ -32,7 +32,7 @@ import {
 import { $findMatchingParent, mergeRegister } from '@lexical/utils'
 import { useEditor } from '../composables'
 import { useMounted } from '../composables/useMounted'
-import { registerClickAndPointerListenersIfUnregistered } from '../composables/listenerManager'
+import { registerClickAndPointerListeners } from '../composables/listenerManager'
 
 const editor = useEditor()
 
@@ -138,7 +138,7 @@ useMounted(() => {
 })
 
 function listenPointerDown() {
-  return registerClickAndPointerListenersIfUnregistered(() => {
+  return registerClickAndPointerListeners(() => {
     // @ts-expect-error: speculation ambiguous
     document.addEventListener('click', handleClick)
     document.addEventListener('pointerdown', handlePointerDown)

--- a/src/composables/listenerManager.ts
+++ b/src/composables/listenerManager.ts
@@ -1,9 +1,10 @@
-let handleClickAndPointerDownListenersCount = 0
+let handleClickAndPointerDownListenersRegistered = false
 
-export function incrementCheckListListenersCount() {
-  return handleClickAndPointerDownListenersCount++ === 0
-}
+export function registerClickAndPointerListenersIfUnregistered(register: () => void, unregister: () => void) {
+  if (handleClickAndPointerDownListenersRegistered)
+    return () => {}
 
-export function decrementCheckListListenersCount() {
-  return --handleClickAndPointerDownListenersCount === 0
+  handleClickAndPointerDownListenersRegistered = true
+  register()
+  return unregister
 }

--- a/src/composables/listenerManager.ts
+++ b/src/composables/listenerManager.ts
@@ -1,10 +1,16 @@
-let handleClickAndPointerDownListenersRegistered = false
+let handleClickAndPointerDownListenersCount = 0
+let handleClickAndPointerDownListenersUnregister: (() => void) | undefined
 
-export function registerClickAndPointerListenersIfUnregistered(register: () => void, unregister: () => void) {
-  if (handleClickAndPointerDownListenersRegistered)
-    return () => {}
+export function registerClickAndPointerListeners(register: () => void, unregister: () => void) {
+  if (handleClickAndPointerDownListenersCount++ === 0) {
+    register()
+    handleClickAndPointerDownListenersUnregister = unregister
+  }
 
-  handleClickAndPointerDownListenersRegistered = true
-  register()
-  return unregister
+  return () => {
+    if (--handleClickAndPointerDownListenersCount === 0) {
+      handleClickAndPointerDownListenersUnregister?.()
+      handleClickAndPointerDownListenersUnregister = undefined
+    }
+  }
 }


### PR DESCRIPTION
# Background
The fix that I implemented in #20 helped but did not fix all cases. Because `removeEventListener` requires the exact same function to be passed to it that was originally passed to `addEventListener`, calling unregister from a different editor doesn't do anything, leaving the listeners. This is a memory leak but more importantly it means that if you later reregister listeners, there are an even number, and checklist clicks again do not work.

# Repro
1. Make one editor and then another, each with the checklist plugin
2. Remove the first one, then the second one (the second one tries to clean up the listeners that the first one registered, which doesn't work)
3. Add another editor (which re-adds listeners, for a total of two) and observe that checklist boxes don't change (or, rather, change twice) on click

# Fix
This fix uses the same patterns but simplifies the listenerManager signature and ensures that the final unregistration calls the reverse of the original registration.