### PR TITLE
Fix/commonjs for vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.cjs"
     }
   },
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "files": [

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   dts: false,
   outExtension({ format }) {
     return {
-      js: format === 'esm' ? '.mjs' : '.js',
+      js: format === 'esm' ? '.mjs' : '.cjs',
     }
   },
   esbuildPlugins: [vuePlugin()],


### PR DESCRIPTION
When I was using [lexical-markdown-vue](https://github.com/tatfook/lexical-markdown-showcase/tree/feature/separate-package/packages/lexical-markdown-vue) which is dependent lexical-vue on nuxt@3, it comes an error:
![image](https://github.com/wobsoriano/lexical-vue/assets/16633962/052f12ea-2e7f-45d0-b074-eec5edc30cc1)
Then I change the file name from index.js to index.cjs