### PR TITLE
fix: playground checklist not work

### DIFF
--- a/playground/src/Editor.vue
+++ b/playground/src/Editor.vue
@@ -7,6 +7,7 @@ import {
   LexicalLinkPlugin,
   LexicalListPlugin,
   LexicalRichTextPlugin,
+  LexicalCheckListPlugin,
 } from 'lexical-vue'
 
 import EmojisPlugin from './plugins/EmojisPlugin.vue'
@@ -48,6 +49,7 @@ import TwitterPlugin from './plugins/TwitterPlugin/index.vue'
       <LexicalAutoFocusPlugin />
       <CodeHighlightPlugin />
       <LexicalListPlugin />
+      <LexicalCheckListPlugin />
       <LexicalLinkPlugin />
       <AutoLinkPlugin />
       <ListMaxIndentLevelPlugin :max-depth="7" />


### PR DESCRIPTION
#43 
missing ```CheckListPlugin``` for change block to check list block.