### PR TITLE
Bugfix "[object Object]" when switching font in playground

### DIFF
--- a/playground/src/plugins/ToolbarPlugin/FontDropDown.vue
+++ b/playground/src/plugins/ToolbarPlugin/FontDropDown.vue
@@ -63,7 +63,7 @@ const FONT_SIZE_OPTIONS: [string, string][] = [
       v-for="[option, text] in (customStyle === 'font-family' ? FONT_FAMILY_OPTIONS : FONT_SIZE_OPTIONS)"
       :key="option"
       :class="`item ${dropDownActiveClass(value === option)} ${customStyle === 'font-size' ? 'fontsize-item' : ''}`"
-      @click="handleClick"
+      @click="handleClick(option)"
     >
       <span class="text">{{ text }}</span>
     </DropDownItem>


### PR DESCRIPTION
I was messing around with the playground and it have a bug when switching the font type. If you select other font type it does not work and the placeholder shows "[object Object]"

You can watch it in the following image:
![image](https://github.com/wobsoriano/lexical-vue/assets/27807324/8f85967a-a80c-40d5-926f-dadfb89bf1fd)