### PR TITLE
Check menu is not empty

### DIFF
--- a/.changeset/ten-cats-poke.md
+++ b/.changeset/ten-cats-poke.md
@@ -2,4 +2,4 @@
 "lexical-vue": patch
 ---
 
-Fix incorrect element returned by Menu plugin
+Fix incorrect element returned by Typeahead Menu plugin

--- a/.changeset/ten-cats-poke.md
+++ b/.changeset/ten-cats-poke.md
@@ -1,0 +1,5 @@
+---
+"lexical-vue": patch
+---
+
+Fix incorrect element returned by Menu plugin

--- a/src/components/LexicalMenu/shared.ts
+++ b/src/components/LexicalMenu/shared.ts
@@ -162,7 +162,7 @@ export function useMenuAnchorRef(
     const rootElement = editor.getRootElement()
     const containerDiv = anchorElementRef.value
 
-    const menuEle = containerDiv.firstChild as HTMLElement
+    const menuEle = containerDiv.firstElementChild as HTMLElement
     if (rootElement !== null && resolution.value !== null) {
       const { left, top, width, height } = resolution.value!.getRect()
       const anchorHeight = anchorElementRef.value.offsetHeight // use to position under anchor


### PR DESCRIPTION
fix issue: #62 

- firstChild returns the first child node of any type (element node, text node, or comment node).
- If containerDiv contains only whitespace (like a newline or space), firstChild will still return a text node, and it won't be considered empty in this check.

Therefore, use firstElementChild instead.