### PR TITLE
Add `InitialConfigType` as the type for the `LexicalComposer` props

### DIFF
--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
-import type { CreateEditorArgs } from 'lexical'
 import { $createParagraphNode, $createTextNode, $getRoot } from 'lexical'
-import { LexicalComposer } from 'lexical-vue'
+import { type InitialConfigType, LexicalComposer } from 'lexical-vue'
 import { $createHeadingNode, $createQuoteNode } from '@lexical/rich-text'
 import { $createListItemNode, $createListNode } from '@lexical/list'
 import { $createLinkNode } from '@lexical/link'
@@ -89,13 +88,17 @@ function prepopulatedRichText() {
   }
 }
 
-const config: CreateEditorArgs = {
+const config: InitialConfigType = {
+  namespace: 'Vue.js Demo',
   theme: PlaygroundEditorTheme,
   nodes: [
     ...PlaygroundNodes,
   ],
   editable: true,
-  editorState: prepopulatedRichText as any,
+  editorState: prepopulatedRichText,
+  onError(error: Error) {
+    throw error
+  },
 }
 
 function onError(error: Error) {

--- a/src/components/LexicalComposer.vue
+++ b/src/components/LexicalComposer.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
 import { onMounted, provide } from 'vue'
-import type { CreateEditorArgs, LexicalEditor } from 'lexical'
+import type { LexicalEditor } from 'lexical'
 import { $createParagraphNode, $getRoot, $getSelection, createEditor } from 'lexical'
 import { LexicalEditorProviderKey } from '../composables/inject'
-import type { InitialEditorStateType } from '../types'
+import type { InitialConfigType, InitialEditorStateType } from '../types'
 
 const props = defineProps<{
-  initialConfig: CreateEditorArgs
+  initialConfig: InitialConfigType
 }>()
 
 const emit = defineEmits<{

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from './composables'
 export * from './components'
+export * from './types'

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,25 @@
-import type { EditorState, LexicalEditor } from 'lexical'
+import type {
+  EditorState,
+  EditorThemeClasses,
+  HTMLConfig,
+  Klass,
+  LexicalEditor,
+  LexicalNode,
+  LexicalNodeReplacement,
+} from 'lexical'
 
 export type InitialEditorStateType =
   | null
   | string
   | EditorState
   | ((editor: LexicalEditor) => void)
+
+export type InitialConfigType = Readonly<{
+  namespace: string
+  nodes?: ReadonlyArray<Klass<LexicalNode> | LexicalNodeReplacement>
+  onError: (error: Error, editor: LexicalEditor) => void
+  editable?: boolean
+  theme?: EditorThemeClasses
+  editorState?: InitialEditorStateType
+  html?: HTMLConfig
+}>


### PR DESCRIPTION
Add the `type InitialConfigType` that follows the type definition of:

https://github.com/facebook/lexical/blob/0d1bb6670f71a70b2ad18243fee7ff4a0309a20f/packages/lexical-react/src/LexicalComposer.tsx#L41

The type is used as the type of the props passed to the `LexicalComposer` to allow a typed initial configuration for the `editorState` and use a function without needing to use `any`.

The commit updates the `playground` example to follow the type:

```
const config: InitialConfigType = {
  namespace: 'Vue.js Demo',
  theme: PlaygroundEditorTheme,
  nodes: [
    ...PlaygroundNodes,
  ],
  editorState: prepopulatedRichText,
  onError(error: Error) {
    throw error
  },
}
```