### PR TITLE
fix: fixed LexicalTypeaheadMenuPlugin options param

### DIFF
--- a/src/components/LexicalTypeaheadMenuPlugin/index.vue
+++ b/src/components/LexicalTypeaheadMenuPlugin/index.vue
@@ -175,7 +175,7 @@ watchEffect((onInvalidate) => {
     :anchor-element-ref="anchorElementRef"
     :editor="editor"
     :resolution="resolution!"
-    :options="options"
+    :options="props.options"
     should-split-node-with-query
     :command-priority="commandPriority"
     :close="closeTypeahead"


### PR DESCRIPTION
The options props is mis-passed to the LexicalMenu component, which causes the component generic type cannot be infered correctly