### PR TITLE
fix: DecoratorNode components not rendered on initial load

### DIFF
--- a/packages/lexical-vue/src/shared/useDecorators.ts
+++ b/packages/lexical-vue/src/shared/useDecorators.ts
@@ -10,6 +10,12 @@ export function useDecorators(editor: LexicalEditor) {
       decorators.value = nextDecorators as Record<string, DefineComponent>
     })
 
+    // Catch any decorators that were computed between setup and onMounted.
+    // ContentEditableElement.setRootElement() triggers reconciliation in its
+    // own onMounted (which fires before this one), so by the time we get here
+    // the decorators are already populated — we just missed the notification.
+    decorators.value = editor.getDecorators() as Record<string, DefineComponent>
+
     onUnmounted(() => {
       unregister()
     })


### PR DESCRIPTION
## Summary

DecoratorNode components (rendered via Vue Teleports) are not visible when the editor initializes with pre-existing decorator nodes in the content. They only appear after the user interacts with the editor (e.g., clicking and pressing Enter).

The root cause is a race condition in `useDecorators` where the decorator listener is registered **after** the initial reconciliation has already fired.

## How the bug manifests

When a Lexical editor is initialized with content that contains `DecoratorNode` instances (e.g., a custom `FileNode` that renders a file preview component):

1. The DOM element created by `DecoratorNode.createDOM()` appears in the editor (a `<span data-lexical-decorator="true">` element).
2. But the Vue component returned by `DecoratorNode.decorate()` is **never teleported** into that span. The span remains empty.
3. The decorator component only appears after any user interaction that triggers an editor update (typing, pressing Enter, etc.).

This affects **all** `DecoratorNode` subclasses.

## Root cause

Vue 3 mounts children depth-first, processing siblings in render order. In `RichTextPlugin`:

```
RichTextPlugin
├── slot(contentEditable)
│   └── ContentEditableElement  ← mounts FIRST
└── LexicalDecoratedTeleports   ← mounts SECOND
```

The sequence:

1. **`ContentEditableElement.onMounted()`** → calls `editor.setRootElement()` → triggers DOM reconciliation → `DecoratorNode.decorate()` computes Vue VNodes → decorator listeners are notified → **but nobody is listening yet**
2. **`LexicalDecoratedTeleports.onMounted()`** (via `useDecorators`) → `registerDecoratorListener()` is called → listener is registered but **missed the notification from step 1**

## The fix

Add a single line in `useDecorators` to re-read the current decorators **after** registering the listener:

```ts
decorators.value = editor.getDecorators() as Record<string, DefineComponent>
```

This closes the gap between the two `onMounted` hooks. It is safe because:
- `getDecorators()` returns `{}` if no decorators exist (no-op for `shallowRef`)
- It does not trigger unnecessary re-renders, history entries, or side effects
- Future decorator changes are still handled by the listener callback

## Reproduction

Any `DecoratorNode` that exists in the initial editor content will reproduce this:

```ts
const editorConfig = {
  nodes: [MyDecoratorNode],
  editorState: () => {
    const root = $getRoot()
    const paragraph = $createParagraphNode()
    paragraph.append($createMyDecoratorNode())
    root.append(paragraph)
  },
}
```

On first render, the decorator component will not be visible. Pressing Enter or typing any character will make it appear.
