### PR TITLE
Document extensions

### DIFF
--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -37,6 +37,16 @@ function sidebarDocs() {
     },
     { text: 'Concepts', link: 'https://lexical.dev/docs/concepts/editor-state' },
     {
+      text: 'Extensions',
+      collapsed: false,
+      items: [
+        { text: 'Introduction', link: '/docs/extensions/introduction' },
+        { text: 'Using Extensions', link: '/docs/extensions/usage' },
+        { text: 'Contributing Vue UI', link: '/docs/extensions/vue-ui' },
+        { text: 'Reading Extension State', link: '/docs/extensions/signals' },
+      ],
+    },
+    {
       text: 'Plugins',
       collapsible: false,
       items: [

--- a/apps/docs/docs/extensions/introduction.md
+++ b/apps/docs/docs/extensions/introduction.md
@@ -1,0 +1,78 @@
+# Extensions
+
+An extension is a self-contained piece of editor behaviour that carries its own nodes, its own registration and its own configuration. Lexical ships extensions for rich text, history, lists, links, tables and much else, and they are framework agnostic, so the same `RichTextExtension` works in Vue, React and Svelte.
+
+Extensions are additive. `LexicalComposer` and the plugin components are not going anywhere, and everything you have already built keeps working exactly as it does today.
+
+## Why a separate composer
+
+An extension can only run on an editor that was created through the extension API. `LexicalComposer` calls `createEditor()` directly, so extensions do not work inside it. `LexicalExtensionComposer` builds the editor with `buildEditorFromExtensions()` instead, which is what makes them work.
+
+Both composers provide the editor on the same injection key, so every existing lexical-vue component resolves inside either one.
+
+## What changes for you
+
+Compare a plain text editor built the established way:
+
+```vue
+<script setup lang="ts">
+import { LexicalComposer } from 'lexical-vue/LexicalComposer'
+import { ContentEditable } from 'lexical-vue/LexicalContentEditable'
+import { HistoryPlugin } from 'lexical-vue/LexicalHistoryPlugin'
+import { RichTextPlugin } from 'lexical-vue/LexicalRichTextPlugin'
+
+const config = {
+  namespace: 'MyEditor',
+  nodes: [HeadingNode, QuoteNode],
+  onError: console.error,
+}
+</script>
+
+<template>
+  <LexicalComposer :initial-config="config">
+    <RichTextPlugin>
+      <template #contentEditable>
+        <ContentEditable />
+      </template>
+    </RichTextPlugin>
+    <HistoryPlugin />
+  </LexicalComposer>
+</template>
+```
+
+against the same editor built from extensions:
+
+```vue
+<script setup lang="ts">
+import { HistoryExtension } from '@lexical/history'
+import { RichTextExtension } from '@lexical/rich-text'
+import { defineExtension } from 'lexical'
+import { ContentEditable } from 'lexical-vue/LexicalContentEditable'
+import { LexicalExtensionComposer } from 'lexical-vue/LexicalExtensionComposer'
+
+const extension = defineExtension({
+  name: 'MyEditor',
+  namespace: 'MyEditor',
+  dependencies: [RichTextExtension, HistoryExtension],
+})
+</script>
+
+<template>
+  <LexicalExtensionComposer :extension="extension">
+    <ContentEditable />
+  </LexicalExtensionComposer>
+</template>
+```
+
+There is no `nodes` array and no `RichTextPlugin`. `RichTextExtension` declares `nodes: () => [HeadingNode, QuoteNode]` and runs `registerRichText` itself, so one dependency covers what previously took configuration in one place and registration in another.
+
+## Where to read more
+
+The extension system itself is documented upstream and applies to every framework. Those pages are the reference for the concepts.
+
+- [Extensions introduction](https://lexical.dev/docs/extensions/intro) for the core API and the use case.
+- [Defining extensions](https://lexical.dev/docs/extensions/defining-extensions) for writing your own.
+- [Included extensions](https://lexical.dev/docs/extensions/included-extensions) for the full list of what ships.
+- [Peer dependencies](https://lexical.dev/docs/extensions/peer-dependencies) for optional integration between extensions.
+
+The pages in this section cover only what is specific to Vue.

--- a/apps/docs/docs/extensions/signals.md
+++ b/apps/docs/docs/extensions/signals.md
@@ -1,0 +1,60 @@
+# Reading extension state
+
+Extensions expose their state as [signals](https://lexical.dev/docs/extensions/signals). A signal is a small reactive value that any framework can subscribe to, which is how one extension serves Vue, React and Svelte at once.
+
+lexical-vue mirrors a signal into a Vue ref, so you read extension state the same way you read anything else.
+
+## useExtensionSignalValue
+
+The shortest path. Give it an extension and the name of a signal in its output, and get a ref back.
+
+```vue
+<script setup lang="ts">
+import { useExtensionSignalValue } from 'lexical-vue/useExtensionSignalValue'
+import { WordCountExtension } from './WordCountExtension'
+
+const count = useExtensionSignalValue(WordCountExtension, 'count')
+</script>
+
+<template>
+  <div>{{ count }} words</div>
+</template>
+```
+
+The ref updates whenever the signal does, and the subscription is released when the component unmounts.
+
+## useExtensionDependency
+
+Some extensions expose their output as a single signal rather than a named collection. `EditorStateExtension` is one, and its whole output is a signal carrying the current `EditorState`.
+
+```vue
+<script setup lang="ts">
+import { EditorStateExtension } from '@lexical/extension'
+import { useExtensionDependency } from 'lexical-vue/useExtensionDependency'
+import { useSignalValue } from 'lexical-vue/useExtensionSignalValue'
+
+const editorState = useSignalValue(useExtensionDependency(EditorStateExtension).output)
+</script>
+```
+
+`useExtensionDependency` resolves an extension against the current editor and gives you both its `config` and its `output`. It throws when the extension is not part of the editor, which catches a missing dependency at the point of use.
+
+## useSignalValue
+
+The primitive underneath both. It takes any signal and returns a readonly ref.
+
+```ts
+import { useSignalValue } from 'lexical-vue/useExtensionSignalValue'
+
+const value = useSignalValue(someSignal)
+```
+
+The ref is shallow, so the value inside it is the value the signal holds and not a reactive proxy of it. That matters for identity comparisons:
+
+```ts
+editorState.value === editor.getEditorState() // true
+```
+
+::: warning
+`useSignalValue` binds its subscription to the current Vue effect scope. Call it during `setup` or inside an `effectScope`, otherwise nothing will release the subscription.
+:::

--- a/apps/docs/docs/extensions/usage.md
+++ b/apps/docs/docs/extensions/usage.md
@@ -1,0 +1,73 @@
+# Using extensions
+
+`LexicalExtensionComposer` takes a single `extension` prop and builds the editor from it.
+
+```vue
+<script setup lang="ts">
+import { HistoryExtension } from '@lexical/history'
+import { ListExtension } from '@lexical/list'
+import { RichTextExtension } from '@lexical/rich-text'
+import { defineExtension } from 'lexical'
+import { ContentEditable } from 'lexical-vue/LexicalContentEditable'
+import { LexicalExtensionComposer } from 'lexical-vue/LexicalExtensionComposer'
+
+const extension = defineExtension({
+  name: 'MyEditor',
+  namespace: 'MyEditor',
+  dependencies: [RichTextExtension, HistoryExtension, ListExtension],
+  theme: {
+    // Theme styling goes here
+  },
+})
+</script>
+
+<template>
+  <LexicalExtensionComposer :extension="extension">
+    <ContentEditable />
+  </LexicalExtensionComposer>
+</template>
+```
+
+## Existing components still work
+
+Anything that reaches the editor through `useLexicalComposer()` works inside the extension composer with no changes, because both composers provide the editor the same way.
+
+That means you can adopt extensions gradually. Take the behaviour you want from extensions and keep using plugin components for the rest.
+
+```vue
+<template>
+  <LexicalExtensionComposer :extension="extension">
+    <ContentEditable />
+    <OnChangePlugin @change="onChange" />
+    <MyOwnPlugin />
+  </LexicalExtensionComposer>
+</template>
+```
+
+::: tip
+Do not add `RichTextPlugin` when your extension already depends on `RichTextExtension`. The extension performs the same registration, so you would be doing it twice.
+:::
+
+## The editor is built once
+
+The editor is built during setup, and a later change to the `extension` prop is ignored. Rebuilding would discard whatever the user has typed, so it is not something to do implicitly.
+
+When you genuinely need a fresh editor, bind a `key` to whatever the extension is derived from:
+
+```vue
+<template>
+  <LexicalExtensionComposer :key="documentId" :extension="extension">
+    <ContentEditable />
+  </LexicalExtensionComposer>
+</template>
+```
+
+## Decorator nodes
+
+Decorator nodes render automatically. The composer hosts them, so images, embeds, equations and any custom `DecoratorNode` appear without you rendering anything extra.
+
+If you nest `RichTextPlugin` or `PlainTextPlugin` inside the composer, they will not render decorators a second time. Exactly one host renders them, whichever arrangement you use.
+
+## Disposal
+
+The composer disposes the editor it built when the component unmounts. You do not need to call `editor.dispose()` yourself.

--- a/apps/docs/docs/extensions/vue-ui.md
+++ b/apps/docs/docs/extensions/vue-ui.md
@@ -1,0 +1,96 @@
+# Contributing Vue UI
+
+Most extensions only register behaviour and render nothing. Some need to put something on screen, such as a floating toolbar or a find and replace panel. `VueExtension` is the channel for that.
+
+An extension that contributes UI depends on `VueExtension` with a config override, and the composer renders whatever it contributes.
+
+```ts
+import { configExtension, defineExtension } from 'lexical'
+import { VueExtension } from 'lexical-vue/VueExtension'
+import MentionsPanel from './MentionsPanel.vue'
+import { MentionNode } from './MentionNode'
+
+export const MentionsExtension = defineExtension({
+  name: '@app/Mentions',
+  nodes: [MentionNode],
+  dependencies: [configExtension(VueExtension, { decorators: [MentionsPanel] })],
+})
+```
+
+The app adds the extension and nothing else. It does not need to know the panel exists, or to render it.
+
+```vue
+<template>
+  <LexicalExtensionComposer :extension="extension">
+    <ContentEditable />
+  </LexicalExtensionComposer>
+</template>
+```
+
+Contributed UI renders inside the editor's context, so it reaches the editor with `useLexicalComposer()` exactly like any component you write yourself.
+
+```vue
+<script setup lang="ts">
+import { useLexicalComposer } from 'lexical-vue/LexicalComposer'
+
+const editor = useLexicalComposer()
+</script>
+```
+
+## Decorators concatenate
+
+Every extension in the graph contributes. Configs merge by concatenation rather than replacement, so two extensions that each add a decorator both get rendered and neither overwrites the other.
+
+```ts
+const extension = defineExtension({
+  name: '@app/Editor',
+  dependencies: [RichTextExtension, MentionsExtension, FindReplaceExtension],
+})
+```
+
+## What a decorator can be
+
+A decorator is either a component or a vnode.
+
+```ts
+configExtension(VueExtension, {
+  decorators: [MentionsPanel, () => h(Toolbar, { compact: true })],
+})
+```
+
+Use a component when it takes no props. Use an arrow returning a vnode when you need to pass props, since a Vue functional component is just a function returning a vnode.
+
+::: tip
+Props are not passed to a contributed decorator. Reach the editor through `useLexicalComposer()` and read extension state through the [signal composables](./signals).
+:::
+
+## Supplying the editable region
+
+An extension can also own the editable region itself, through the `contentEditable` config. This is mainly useful for an extension that ships a complete editor, such as a nested caption editor.
+
+```ts
+configExtension(VueExtension, {
+  contentEditable: () => h(ContentEditable, { class: 'caption' }),
+})
+```
+
+It defaults to `null`, which is why the composer renders nothing extra when you put `<ContentEditable />` in the default slot yourself. That default differs from `@lexical/react` deliberately. If both the config value and your own `ContentEditable` rendered, the editor would end up with two root elements competing for the same editor.
+
+To override an extension's `contentEditable`, use the composer's `contentEditable` slot:
+
+```vue
+<template>
+  <LexicalExtensionComposer :extension="extension">
+    <template #contentEditable>
+      <ContentEditable class="my-own-editable" />
+    </template>
+    <MyToolbar />
+  </LexicalExtensionComposer>
+</template>
+```
+
+The slot wins over the config value, so an extension supplies a default and the app keeps the last word.
+
+## Requiring a Vue host
+
+`VueExtension` declares a peer dependency on `VueProviderExtension`, which `LexicalExtensionComposer` always includes. Building an editor that wants Vue UI without a Vue host to render it fails immediately with a message naming the extension that asked for it, rather than silently rendering nothing.

--- a/packages/lexical-vue/tests/docs-examples.test.ts
+++ b/packages/lexical-vue/tests/docs-examples.test.ts
@@ -1,0 +1,131 @@
+import type { EditorState } from 'lexical'
+import type { ShallowRef } from 'vue'
+import { EditorStateExtension, namedSignals } from '@lexical/extension'
+import { HistoryExtension } from '@lexical/history'
+import { ListExtension } from '@lexical/list'
+import { RichTextExtension } from '@lexical/rich-text'
+import { mount } from '@vue/test-utils'
+import { configExtension, defineExtension } from 'lexical'
+import { expect, test } from 'vite-plus/test'
+import { defineComponent, h } from 'vue'
+import { useLexicalComposer } from '../src/LexicalComposer'
+import { ContentEditable } from '../src/LexicalContentEditable'
+import { LexicalExtensionComposer } from '../src/LexicalExtensionComposer'
+import { useExtensionDependency } from '../src/useExtensionDependency'
+import { useExtensionSignalValue, useSignalValue } from '../src/useExtensionSignalValue'
+import { VueExtension } from '../src/VueExtension'
+
+test('extensions/usage.md: the editor example builds with namespace and theme', () => {
+  const extension = defineExtension({
+    name: 'MyEditor',
+    namespace: 'MyEditor',
+    dependencies: [RichTextExtension, HistoryExtension, ListExtension],
+    theme: {},
+  })
+  const wrapper = mount(
+    defineComponent({
+      setup: () => () =>
+        h(LexicalExtensionComposer, { extension }, { default: () => [h(ContentEditable)] }),
+    }),
+    { attachTo: document.body },
+  )
+
+  expect(
+    wrapper.find('[contenteditable]').exists(),
+    'the documented extension editor renders an editable region',
+  ).toBe(true)
+  wrapper.unmount()
+})
+
+test('extensions/vue-ui.md: a contributed decorator renders and reaches the editor', () => {
+  const MentionsPanel = defineComponent({
+    name: 'MentionsPanel',
+    setup() {
+      useLexicalComposer()
+      return () => h('div', { 'data-mentions': '' })
+    },
+  })
+  const MentionsExtension = defineExtension({
+    name: '@app/Mentions',
+    dependencies: [configExtension(VueExtension, { decorators: [MentionsPanel] })],
+  })
+  const extension = defineExtension({
+    name: '@app/Editor',
+    dependencies: [RichTextExtension, MentionsExtension],
+  })
+  const wrapper = mount(
+    defineComponent({
+      setup: () => () =>
+        h(LexicalExtensionComposer, { extension }, { default: () => [h(ContentEditable)] }),
+    }),
+    { attachTo: document.body },
+  )
+
+  expect(
+    wrapper.findAll('[data-mentions]').length,
+    'the extension contributes UI without the app rendering it',
+  ).toBe(1)
+  wrapper.unmount()
+})
+
+test('extensions/vue-ui.md: an arrow decorator passing props renders', () => {
+  const Toolbar = defineComponent({
+    name: 'Toolbar',
+    props: { compact: { type: Boolean, default: false } },
+    setup: (props) => () => h('div', { 'data-compact': String(props.compact) }),
+  })
+  const extension = defineExtension({
+    name: '@app/WithToolbar',
+    dependencies: [
+      RichTextExtension,
+      configExtension(VueExtension, { decorators: [() => h(Toolbar, { compact: true })] }),
+    ],
+  })
+  const wrapper = mount(
+    defineComponent({ setup: () => () => h(LexicalExtensionComposer, { extension }) }),
+    { attachTo: document.body },
+  )
+
+  expect(
+    wrapper.find('[data-compact]').attributes('data-compact'),
+    'the arrow form passes props to the contributed component',
+  ).toBe('true')
+  wrapper.unmount()
+})
+
+test('extensions/signals.md: both documented signal reads work', () => {
+  const WordCountExtension = defineExtension({
+    name: '@app/WordCount',
+    dependencies: [RichTextExtension],
+    build: () => namedSignals({ count: 0 }),
+  })
+  const extension = defineExtension({
+    name: '@app/SignalsDoc',
+    dependencies: [WordCountExtension, EditorStateExtension],
+  })
+
+  let count!: Readonly<ShallowRef<number>>
+  let editorState!: Readonly<ShallowRef<EditorState>>
+  let editor!: ReturnType<typeof useLexicalComposer>
+  const Inner = defineComponent({
+    setup() {
+      editor = useLexicalComposer()
+      count = useExtensionSignalValue(WordCountExtension, 'count')
+      editorState = useSignalValue(useExtensionDependency(EditorStateExtension).output)
+      return () => h(ContentEditable)
+    },
+  })
+  const wrapper = mount(
+    defineComponent({
+      setup: () => () => h(LexicalExtensionComposer, { extension }, { default: () => [h(Inner)] }),
+    }),
+    { attachTo: document.body },
+  )
+
+  expect(count.value, 'useExtensionSignalValue reads a named signal').toBe(0)
+  expect(
+    editorState.value,
+    'the documented identity comparison holds, so the ref is not a reactive proxy',
+  ).toBe(editor.getEditorState())
+  wrapper.unmount()
+})


### PR DESCRIPTION
Adds an Extensions section to the docs. Everything shipped in #105, #107 and #108 was undiscoverable, since the docs had no mention of extensions anywhere.

## Four pages

**Introduction.** What an extension is, why it needs its own composer (`LexicalComposer` calls `createEditor()` directly, so extensions do not work inside it), and the same editor written both ways side by side.

**Using Extensions.** The composer, gradual adoption alongside existing plugin components, the build-once behaviour and the `key` escape hatch, and decorator nodes.

**Contributing Vue UI.** `VueExtension`, decorator concatenation across extensions, what a decorator can be, and the `contentEditable` config with its slot override.

**Reading Extension State.** `useExtensionSignalValue`, `useExtensionDependency` and `useSignalValue`, including why the ref is shallow.

## What is deliberately not here

The framework-agnostic concepts are not duplicated. Upstream documents the extension system itself for every framework, so intro, defining extensions, included extensions and peer dependencies are linked rather than restated. These four pages cover only what is specific to Vue.

`getting-started/usage.md`, both plugins pages and the playground are untouched. Extensions are presented as an available path rather than the default one, which matches how upstream still stages its own React docs.

## Verification

Every documented example is exercised by `tests/docs-examples.test.ts`: the editor built with `namespace` and `theme`, a contributed decorator reaching the editor through `useLexicalComposer()`, the arrow form passing props, and both signal reads including the identity comparison the signals page claims holds.

`vp run ready` green, 66 tests up from 62, and the VitePress build passes with all four pages emitted and the sidebar wired.

Writing the examples as tests is the point rather than a formality. A docs example that does not compile is worse than no example, and this is what keeps them from rotting as the API moves.
